### PR TITLE
Update recipe.yaml to fix bioio-base pinning to match pyproject.toml

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 8be25df70b611e62d1f1c3b11b47e039f3626e08e17e0dc792d824be3e4aeb89
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -28,7 +28,8 @@ requirements:
     - pip
   run:
     - python >=${{ python_min }}
-    - bioio-base ==3.0.0
+    # bioio-base version must always match bioio version
+    - bioio-base ==${{ version }}
     - dask-core >=2021.4.1
     - fsspec >=2022.8.0
     - imageio >=2.11.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -28,7 +28,7 @@ requirements:
     - pip
   run:
     - python >=${{ python_min }}
-    - bioio-base ==1.0.7
+    - bioio-base ==3.0.0
     - dask-core >=2021.4.1
     - fsspec >=2022.8.0
     - imageio >=2.11.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -28,8 +28,7 @@ requirements:
     - pip
   run:
     - python >=${{ python_min }}
-    # bioio-base version must always match bioio version
-    - bioio-base ==${{ version }}
+    - bioio-base ==3.0.0
     - dask-core >=2021.4.1
     - fsspec >=2022.8.0
     - imageio >=2.11.0


### PR DESCRIPTION
See issue reported at:
https://forum.image.sc/t/scene-not-changing-in-bioio-czi-installed-with-pixi/115986/4
Upstream bioio pyproject.toml pins bioio-base to the current bioio version:
https://github.com/bioio-devs/bioio/blob/2f59ef839f119049eccbb4f6e9ee19ae1e579e77/pyproject.toml#L34
Here that is not the case and an older version of bioio-base is pulled.
Dan clarified that the `bioio-base` version pin should always be updated for the version pin in the pyproject.toml -- it may not always match the bioio version. This means this feedstock must not automerge.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
